### PR TITLE
To include RGB+W matrices

### DIFF
--- a/examples/matrixtest/matrixtest.pde
+++ b/examples/matrixtest/matrixtest.pde
@@ -27,6 +27,7 @@
 //   NEO_KHZ800  800 KHz bitstream (most NeoPixel products w/WS2812 LEDs)
 //   NEO_KHZ400  400 KHz (classic 'v1' (not v2) FLORA pixels, WS2811 drivers)
 //   NEO_GRB     Pixels are wired for GRB bitstream (most NeoPixel products)
+//   NEO_GRBW    Pixels are wired for GRBW bitstream (RGB+W NeoPixel products)
 //   NEO_RGB     Pixels are wired for RGB bitstream (v1 FLORA pixels, not v2)
 
 


### PR DESCRIPTION
This will only modify the comment section above Adafruit_NeoMatrix's instantiation. 
It currently did not list the `NEO_GRBW` neoPixelType as an option for parameter 5.
This will give beginners owners of the RGB+W NeoPixel matrix an idea what to modify to get started.

I have tested this on my Mega2560 + RGBW matrix.