### PR TITLE
[Destructor] Add virtual destructor to allow better memory management

### DIFF
--- a/Adafruit_NeoMatrix.h
+++ b/Adafruit_NeoMatrix.h
@@ -117,7 +117,8 @@ public:
                                           NEO_TILE_LEFT + NEO_TILE_ROWS,
                      neoPixelType ledType = NEO_GRB + NEO_KHZ800);
 
-  virtual ~Adafruit_NeoMatrix() {} // Virtual destructor to allow better memory management
+  virtual ~Adafruit_NeoMatrix() {
+  } // Virtual destructor to allow better memory management
 
   /**
    * @brief  Pixel-drawing function for Adafruit_GFX.

--- a/Adafruit_NeoMatrix.h
+++ b/Adafruit_NeoMatrix.h
@@ -117,6 +117,8 @@ public:
                                           NEO_TILE_LEFT + NEO_TILE_ROWS,
                      neoPixelType ledType = NEO_GRB + NEO_KHZ800);
 
+  virtual ~Adafruit_NeoMatrix() {} // Virtual destructor to allow better memory management
+
   /**
    * @brief  Pixel-drawing function for Adafruit_GFX.
    * @param  x      Pixel column (0 = left edge, unless rotation used).


### PR DESCRIPTION
- Adds a virtual destructor, to allow the created instance to be deleted without compiler warnings when used in a plugin-based infrastructure
- Tested (and used) on the letscontrolit/ESPEasy project